### PR TITLE
Use the GSAP eventCallback to attach all the event listeners instead of the transition methods

### DIFF
--- a/docs/guide/muban/README.md
+++ b/docs/guide/muban/README.md
@@ -344,7 +344,7 @@ const MyComponent = defineComponent({
 ```
 
 ::: warning 
-You lose the transition events when you use the scroll transition hook.
+When using this hook there will be no Promise returned by the `transitionIn` / `transitionOut` methods, you can still use the regular event callbacks in the setupOptions though. 
 :::
 
 

--- a/packages/core-transition-component/src/index.ts
+++ b/packages/core-transition-component/src/index.ts
@@ -21,7 +21,6 @@ export type {
   SetupTransitionOptions,
   TransitionController,
   GuardFunction,
-  SetupScrollTransitionOptions,
   TimelineOptions,
   TransitionInOptions,
   TransitionOutOptions,

--- a/packages/core-transition-component/src/types/Transition.types.ts
+++ b/packages/core-transition-component/src/types/Transition.types.ts
@@ -73,9 +73,3 @@ export type SetupPageTransitionOptions<
   beforeTransitionIn?: GuardFunction;
   beforeTransitionOut?: GuardFunction;
 } & SetupTransitionOptions<T, R, E>;
-
-export type SetupScrollTransitionOptions<
-  T extends Record<string, R>,
-  R extends TransitionRef = TransitionRef,
-  E extends SetupSignatureElements<T> = SetupSignatureElements<T>
-> = Omit<SetupTransitionOptions<T, R, E>, 'onStart' | 'onComplete' | 'onUpdate'>;

--- a/packages/muban-transition-component/src/hooks/useScrollTransition.ts
+++ b/packages/muban-transition-component/src/hooks/useScrollTransition.ts
@@ -1,7 +1,7 @@
 import gsap from 'gsap';
 import ScrollTrigger from 'gsap/ScrollTrigger';
 
-import type { SetupScrollTransitionOptions } from '@mediamonks/core-transition-component';
+import type { SetupTransitionOptions } from '@mediamonks/core-transition-component';
 import { createContext } from '@muban/muban';
 import { useTransitionController } from './useTransitionController';
 import type {
@@ -25,7 +25,7 @@ export function useScrollTransition<
   E extends SetupSignatureElements<T> = SetupSignatureElements<T>
 >(
   container: TransitionRefElement,
-  { scrollTrigger = {}, ...restOptions }: SetupScrollTransitionOptions<T, R, E>,
+  { scrollTrigger = {}, ...restOptions }: SetupTransitionOptions<T, R, E>,
 ): ReturnType<typeof useTransitionController> {
   const trigger = transitionRefToElement(container);
   const { scrollTriggerVariables = defaultScrollTriggerVariables } = useScrollContext() || {};

--- a/packages/muban-transition-component/src/index.ts
+++ b/packages/muban-transition-component/src/index.ts
@@ -32,5 +32,4 @@ export type {
   SetupTransitionSignature,
   SetupPageTransitionOptions,
   SetupTransitionOptions,
-  SetupScrollTransitionOptions,
 } from './types/Transition.types';

--- a/packages/muban-transition-component/src/types/Transition.types.ts
+++ b/packages/muban-transition-component/src/types/Transition.types.ts
@@ -13,7 +13,6 @@ import type {
   SetupTransitionSignature as CoreSetupTransitionSignature,
   SetupTransitionOptions as CoreSetupTransitionOptions,
   SetupPageTransitionOptions as CoreSetupPageTransitionOptions,
-  SetupScrollTransitionOptions as CoreSetupScrollTransitionOptions,
 } from '@mediamonks/core-transition-component';
 
 export type TransitionRefCollection =
@@ -51,9 +50,3 @@ export type SetupPageTransitionOptions<
   R extends TransitionRef = TransitionRef,
   E extends SetupSignatureElements<T> = SetupSignatureElements<T>
 > = CoreSetupPageTransitionOptions<T, R, E>;
-
-export type SetupScrollTransitionOptions<
-  T extends Record<string, R>,
-  R extends TransitionRef = TransitionRef,
-  E extends SetupSignatureElements<T> = SetupSignatureElements<T>
-> = CoreSetupScrollTransitionOptions<T, R, E>;


### PR DESCRIPTION
This PR makes sure the eventCallbacks are used to attach transition events, this way we can also use the event callbacks on the ScrollTransitions

fixes #5