### PR TITLE
Feature/add a reset timeline method and make sure scroll trigger is updated

### DIFF
--- a/docs/guide/muban/README.md
+++ b/docs/guide/muban/README.md
@@ -154,7 +154,6 @@ setupTransitionInTimeline: (timeline, { someRef }, transitionContext) => {
 ```
 
 #### Separating your transition logic
-
 When your timelines becomes more complex and grows in size you might want to consider moving your setup functions to a separate file (for example: `myComponent.transitions.ts`).
 
 ```ts
@@ -251,7 +250,7 @@ import { getTimeline } from './SomeComponent.transitions.ts';
     // In this example we watch some ref that might change due to a 
     // window resize or what ever you can think of.
     watch(someRef, () => {
-      transitionController.setupTimeline({ direction: 'in', reset: true })
+      transitionController.resetTimeline('in');
     });
       
     return [];
@@ -418,6 +417,37 @@ This triggering this is very similar to triggering the transition out, so please
 Looping timelines are still a todo! 
 :::
 
+### Resetting timelines
+In some scenarios you might want to reset a timeline, for example you want to use a different timeline on a certain breakpoint.
+
+This can be easily achieved by calling the `resetTimeline` method and providing the desired direction. 
+
+**Supported directions**
+- `in`
+- `out`
+ 
+**Reset the in-transition**
+```ts {14}
+import { defineComponent } from '@muban/muban';
+import { useTransitionController } from '@mediamonks/muban-transition-component';
+ 
+const MyComponent = defineComponent({
+  name: 'some-component',
+  setup() {
+    const transitionController = useTransitionController(refs.self, {
+      setupTransitionInTimeline: (timeline, elements, transitionContext) => {
+        timeline.from(elements.container, { autoAlpha: 0, duration: 1})
+      },
+    });
+
+    // Calling the reset method will re-initialize the timeline
+    transitionController.resetTimeline('in')
+
+    return [];
+  }
+});
+```
+ 
 ### Events
 There are multiple ways to listen to the transition events.
 - Hook callbacks

--- a/examples/muban/package.json
+++ b/examples/muban/package.json
@@ -12,7 +12,6 @@
     "@mediamonks/muban-transition-component": "file:../../packages/muban-transition-component",
     "@muban/muban": "^1.0.0-alpha.27",
     "@muban/template": "^1.0.0-alpha.1",
-    "gsap": "^3.6.1",
     "html-webpack-plugin": "^5.3.1"
   },
   "devDependencies": {

--- a/packages/core-transition-component/package.json
+++ b/packages/core-transition-component/package.json
@@ -33,12 +33,12 @@
     "test": "jest --config ../../jest.config.js"
   },
   "devDependencies": {
-    "gsap": "^3.6.1",
+    "gsap": "^3.7.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.5"
   },
   "gitHead": "f47e239a24df9bed4cf73c47a8ef1267d6da8982",
   "peerDependencies": {
-    "gsap": "^3.6.1"
+    "gsap": "^3.7.0"
   }
 }

--- a/packages/core-transition-component/src/types/transition.types.ts
+++ b/packages/core-transition-component/src/types/transition.types.ts
@@ -24,6 +24,7 @@ export type TransitionDirection = 'in' | 'out';
 export type TransitionController = {
   transitionTimeline: Record<TransitionDirection, gsap.core.Timeline>;
   getTimeline(direction?: TransitionDirection): gsap.core.Timeline;
+  resetTimeline(direction?:TransitionDirection): gsap.core.Timeline;
   setupTimeline(options?: Partial<TimelineOptions>): gsap.core.Timeline;
   transition(options: TransitionOptions): Promise<void>;
   transitionIn(options?: TransitionInOptions): Promise<void>;

--- a/packages/core-transition-component/src/utils/transition.utils.ts
+++ b/packages/core-transition-component/src/utils/transition.utils.ts
@@ -14,11 +14,9 @@ import type {
 import type { AbstractTransitionContext } from '../context/AbstractTransitionContext';
 import { clearTimeline, cloneTimeline } from './timeline.utils';
 
-export function getTransitionController<
-  T extends Record<string, R>,
+export function getTransitionController<T extends Record<string, R>,
   R extends TransitionRef,
-  E extends SetupSignatureElements<T>
->(
+  E extends SetupSignatureElements<T>>(
   container: R,
   setupOptions: SetupTransitionOptions<T, R, E> = {},
   transitionRefToElement: (ref: R) => HTMLElement | Array<HTMLElement> | undefined,
@@ -99,6 +97,16 @@ export function getTransitionController<
       }
 
       return cloneTimeline(transitionTimeline[direction], direction).play();
+    },
+    resetTimeline(direction: TransitionDirection) {
+      const timeline = this.setupTimeline({
+        direction, reset: true,
+      });
+
+      // If the timeline contains a scrollTrigger configuration we should also update that.
+      timeline?.scrollTrigger.update(true);
+
+      return timeline;
     },
     // eslint-disable-next-line no-shadow
     setupTimeline(options: Partial<TimelineOptions> = {}) {

--- a/packages/core-transition-component/src/utils/transition.utils.ts
+++ b/packages/core-transition-component/src/utils/transition.utils.ts
@@ -100,7 +100,8 @@ export function getTransitionController<T extends Record<string, R>,
     },
     resetTimeline(direction: TransitionDirection) {
       const timeline = this.setupTimeline({
-        direction, reset: true,
+        direction,
+        reset: true,
       });
 
       // If the timeline contains a scrollTrigger configuration we should also update that.

--- a/packages/core-transition-component/src/utils/transition.utils.ts
+++ b/packages/core-transition-component/src/utils/transition.utils.ts
@@ -104,8 +104,14 @@ export function getTransitionController<T extends Record<string, R>,
         reset: true,
       });
 
-      // If the timeline contains a scrollTrigger configuration we should also update that.
-      timeline?.scrollTrigger.update(true);
+      // This is not mentioned in the docs, but the method does actually reset the `scrollTrigger` instance and fixes
+      // the issue with re-triggering the scroll events.
+      try {
+        // @ts-ignore
+        timeline?.scrollTrigger.update(true);
+      } catch(error){
+        console.log('Unable to reset the scrollTrigger instance.', error)
+      }
 
       return timeline;
     },

--- a/packages/muban-transition-component/package.json
+++ b/packages/muban-transition-component/package.json
@@ -37,13 +37,13 @@
     "@mediamonks/core-transition-component": "file:../core-transition-component"
   },
   "devDependencies": {
-    "gsap": "^3.6.1",
+    "gsap": "^3.7.0",
     "rimraf": "^3.0.2"
   },
   "gitHead": "f47e239a24df9bed4cf73c47a8ef1267d6da8982",
   "peerDependencies": {
     "@muban/muban": "^1.0.0-alpha.27",
     "@muban/template": "^1.0.0-alpha.1",
-    "gsap": "^3.6.1"
+    "gsap": "^3.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,6 +1965,9 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
+"@mediamonks/core-transition-component@file:packages/core-transition-component":
+  version "1.0.0-alpha.14"
+
 "@mediamonks/eslint-config-base@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@mediamonks/eslint-config-base/-/eslint-config-base-1.0.2.tgz#9e9997eaf00ca9973352f973a672bec5e25104e9"
@@ -1980,6 +1983,11 @@
     eslint-plugin-import "^2.22.1"
     eslint-plugin-prettier "^3.3.1"
     eslint-plugin-unicorn "^27.0.0"
+
+"@mediamonks/muban-transition-component@file:packages/muban-transition-component":
+  version "1.0.0-alpha.18"
+  dependencies:
+    "@mediamonks/core-transition-component" "file:../../../Library/Caches/Yarn/v6/npm-@mediamonks-muban-transition-component-1.0.0-alpha.18-df63752f-38ed-4d76-9c59-3ed2bbbb94ae-1632983488227/node_modules/@mediamonks/core-transition-component"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -7267,10 +7275,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gsap@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/gsap/-/gsap-3.6.1.tgz#618f2338044d2b78b8cbced8ea8bf246d1cf6407"
-  integrity sha512-hCkjk7UVbeEmlpFbiy7lIsh742bwVlMhdCnnQ1CvVOAdURyPX8hXjFZGh/0YzUyAcWPyJPE0/paMhSYtLhGlfA==
+gsap@^3.7.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/gsap/-/gsap-3.8.0.tgz#a404dd6ebbaabc92605539aea9d98e3098688064"
+  integrity sha512-cvpzKkWFePDZCycwXwJnDSpTR3j+a4QLQF/t0c+pXqzRESgAYx5hieaoshzZFjbwsARqr0+5c3GKE7wI273w/g==
 
 gud@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds the following:
- A shorthand for resetting timelines, closes #8.
- When a timeline is being reset we also update the scroll trigger instance if it's available, closes #16