### PR TITLE
Add support for nested timelines with callback functions

### DIFF
--- a/examples/muban/src/components/bar/Bar.transitions.ts
+++ b/examples/muban/src/components/bar/Bar.transitions.ts
@@ -11,5 +11,6 @@ export const setupTransitionInTimeline: SetupTransitionSignature<TransitionRefs>
   timeline,
   { container },
 ) => {
+  timeline.add(() => console.info('Some nested function'));
   timeline.fromTo(container, { scale: 0 }, { scale: 1, duration: 1, ease: 'Bounce.easeOut' });
 };

--- a/packages/core-transition-component/src/utils/timeline.utils.ts
+++ b/packages/core-transition-component/src/utils/timeline.utils.ts
@@ -41,10 +41,10 @@ function parseChildTween(
     );
   }
 
-  if (direction === 'in' && !child.vars.startAt) {
+  // When nesting a timeline we should either have a `startAt` or a function target defined.
+  if (direction === 'in' && (!child.vars.startAt && !child.targets().find((target) => typeof target === 'function'))) {
     throw new Error('Do not use from while nesting transitionInTimelines, use fromTo instead!');
   }
-
   const { startAt: from, ...to } = child.vars;
   const targets = child.targets();
   const startTime = child.startTime();

--- a/packages/core-transition-component/src/utils/timeline.utils.ts
+++ b/packages/core-transition-component/src/utils/timeline.utils.ts
@@ -41,8 +41,11 @@ function parseChildTween(
     );
   }
 
-  // When nesting a timeline we should either have a `startAt` or a function target defined.
-  if (direction === 'in' && (!child.vars.startAt && !child.targets().find((target) => typeof target === 'function'))) {
+  if (
+    direction === 'in' &&
+    // When nesting a timeline we should either have a `startAt` or a function target defined.
+    (!child.vars.startAt && !child.targets().find((target) => typeof target === 'function'))
+  ) {
     throw new Error('Do not use from while nesting transitionInTimelines, use fromTo instead!');
   }
   const { startAt: from, ...to } = child.vars;


### PR DESCRIPTION
This PR updates the check to also allow callback functions in the nested transition in timelines. 

This fixes #15 