### PR TITLE
Do not reset the timeline if the scrollTrigger once is set to true, t…

### DIFF
--- a/packages/muban-transition-component/src/hooks/useScrollTransition.ts
+++ b/packages/muban-transition-component/src/hooks/useScrollTransition.ts
@@ -42,7 +42,7 @@ export function useScrollTransition<
   });
 
   const removeLeaveViewportObserver = addLeaveViewportObserver(trigger, (position) => {
-    if (!scrollTrigger.scrub && position === 'bottom') {
+    if (!scrollTrigger.scrub && !scrollTrigger.once && position === 'bottom') {
       transitionController?.transitionTimeline.in.pause(0, false);
     }
   });


### PR DESCRIPTION
This will make sure a timeline is **not** reset when the `scrollTrigger.once` is set to `true`, this will ensure that the behavior is the same as not using the `useScrollTransition` hook. 

This closes #21 