### PR TITLE
Ensure out-timelines are cleared before re-setting them up in getTime…

### DIFF
--- a/packages/core-transition-component/src/utils/transition.utils.ts
+++ b/packages/core-transition-component/src/utils/transition.utils.ts
@@ -95,6 +95,7 @@ export function getTransitionController<
       if (direction === 'out') {
         this.setupTimeline({
           direction,
+          reset: true,
         });
       }
 


### PR DESCRIPTION
…line

When using the transitionContext to nest a child’s out-timeline in a parent timeline (parentTimeline.add(transitionContext.getTimeline(child, ‘out))), the child’s out timeline is (re) setup, but does not first have its out-timeline cleared.  This leads to appending the out-timeline to itself over and over again.