### PR TITLE
Fix issue where TransitionPresence would transitions on parent rerender

### DIFF
--- a/packages/react-transition-presence/src/TransitionPresence/TransitionPresence.mdx
+++ b/packages/react-transition-presence/src/TransitionPresence/TransitionPresence.mdx
@@ -18,12 +18,57 @@ at the same time with `crossFlow` enabled.
 The most common use-case for `<TransitionPresence />` is animations, but it's not limited to this
 use case.
 
-## Children
+> A `key` prop is required on the children of `<TransitionPresence />` to make sure the transition is
+only triggered when the key changes.
+
+## Props
+
+### Children
 
 `<TransitionPresence />` accepts a single child, use a `Fragment` when you want to render multiple
 components on the root level,
 
-## Defer flow
+The child element must have a unique `key` prop. When rendering a different component, the key must
+be different.
+
+### onStart
+
+The `onStart` is called when the transition starts.
+
+```tsx
+onStart?: () => void;
+
+<TransitionPresence onStart={() => console.log('start')}>
+```
+
+### onComplete
+
+The `onComplete` is called when the transition completes (i.e. when the beforeUnmount of the previous child finishes).
+
+```tsx
+onComplete?: () => void;
+
+<TransitionPresence onComplete={() => console.log('completed')}>
+```
+
+## Examples
+
+### Basic
+
+```tsx
+<TransitionPresence
+  onStart={() => console.log('start')}
+  onComplete={() => console.log('completed')}
+>
+  {isRedVisible ? (
+    <Child key="red" />
+  ) : (
+    <Child key="blue" />
+  )}
+</TransitionPresence>
+```
+
+### Defer flow
 
 By default old children unmount before new children are mounted.
 
@@ -65,6 +110,7 @@ function DeferFlow(): ReactElement {
       <TransitionPresence>
         {isRedVisible ? (
           <Child
+            key="red"
             background="red"
             onClick={(): void => {
               setIsRedVisible(false);
@@ -72,6 +118,7 @@ function DeferFlow(): ReactElement {
           />
         ) : (
           <Child
+            key="blue"
             background="blue"
             onClick={(): void => {
               setIsRedVisible(true);
@@ -86,13 +133,13 @@ function DeferFlow(): ReactElement {
 }
 ```
 
-### Example
+#### Preview
 
 <Canvas>
   <DeferFlow />
 </Canvas>
 
-## Cross flow
+### Cross flow
 
 Use the crossFlow prop on `<TransitionPresence />` to enable cross flow
 
@@ -134,6 +181,7 @@ function CrossFlow(): ReactElement {
       <TransitionPresence crossFlow>
         {isRedVisible ? (
           <Child
+            key="red"
             background="red"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={(): void => {
@@ -142,6 +190,7 @@ function CrossFlow(): ReactElement {
           />
         ) : (
           <Child
+            key="blue"
             background="blue"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={(): void => {
@@ -157,7 +206,7 @@ function CrossFlow(): ReactElement {
 }
 ```
 
-### Example
+#### Preview
 
 <Canvas>
   <CrossFlow />

--- a/packages/react-transition-presence/src/TransitionPresence/TransitionPresence.stories.tsx
+++ b/packages/react-transition-presence/src/TransitionPresence/TransitionPresence.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp, react/jsx-no-literals */
-import { type ReactElement, useState } from 'react';
+import { type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import { useBeforeUnmount } from '../useBeforeUnmount/useBeforeUnmount.js';
 import { TransitionPresence } from './TransitionPresence.js';
 
@@ -12,18 +12,46 @@ type ChildProps = {
   onClick(): void;
 };
 
+// Forces a re-render, useful to test for unwanted side-effects
+function useRerender(): () => void {
+  // eslint-disable-next-line react/hook-use-state
+  const [count, setCount] = useState(0);
+  // eslint-disable-next-line no-console
+  console.log('rerender', count);
+  return () => {
+    setCount((previous) => previous + 1);
+  };
+}
+
 function Child({ background, onClick }: ChildProps): ReactElement {
-  useBeforeUnmount(
-    () =>
-      // Defer unmounting for 1 second
-      new Promise((resolve) => {
-        setTimeout(resolve, 1000);
-      }),
-    [],
-  );
+  const ref = useRef<HTMLButtonElement>(null);
+
+  // show visible animation during "before unmount" lifecycle
+  useBeforeUnmount(() => {
+    const duration = 1000;
+    ref.current?.animate([{ opacity: '0' }], {
+      duration,
+    });
+    // Defer unmounting for 1 second
+    return new Promise((resolve) => {
+      setTimeout(resolve, duration);
+    });
+  }, []);
+
+  // show when mounted/unmounted
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log('mounted', background);
+
+    return () => {
+      // eslint-disable-next-line no-console
+      console.log('unmounted', background);
+    };
+  }, []);
 
   return (
     <button
+      ref={ref}
       aria-label="Click to change color"
       type="button"
       style={{
@@ -73,6 +101,86 @@ export function CrossFlow(): ReactElement {
   return (
     <>
       <TransitionPresence crossFlow>
+        {isRedVisible ? (
+          <Child
+            background="red"
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={(): void => {
+              setIsRedVisible(false);
+            }}
+          />
+        ) : (
+          <Child
+            background="blue"
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={(): void => {
+              setIsRedVisible(true);
+            }}
+          />
+        )}
+      </TransitionPresence>
+
+      <div style={{ marginTop: 24 }}>Click the square (isRedVisible: {String(isRedVisible)})</div>
+    </>
+  );
+}
+
+export function CrossFlowRerender(): ReactElement {
+  const [isRedVisible, setIsRedVisible] = useState(true);
+
+  // trigger rerender in the parent to see how it affects the TransitionPresence
+  const rerender = useRerender();
+
+  const onClickBlue = useCallback(() => {
+    setIsRedVisible(true);
+  }, [setIsRedVisible]);
+
+  const onClickRed = useCallback(() => {
+    setIsRedVisible(false);
+  }, [setIsRedVisible]);
+
+  return (
+    <>
+      <TransitionPresence crossFlow>
+        {isRedVisible ? (
+          <Child key="red" background="red" onClick={onClickRed} />
+        ) : (
+          /* remove key to trigger error log */
+          <Child key="blue" background="blue" onClick={onClickBlue} />
+        )}
+      </TransitionPresence>
+
+      <div style={{ marginTop: 24 }}>Click the square (isRedVisible: {String(isRedVisible)})</div>
+      <button
+        type="button"
+        /* eslint-disable-next-line react/jsx-no-bind */
+        onClick={(): void => {
+          rerender();
+        }}
+      >
+        trigger rerender
+      </button>
+    </>
+  );
+}
+
+export function StartCompleteCallbacks(): ReactElement {
+  const [isRedVisible, setIsRedVisible] = useState(true);
+
+  return (
+    <>
+      <TransitionPresence
+        /* eslint-disable-next-line react/jsx-no-bind,@typescript-eslint/explicit-function-return-type */
+        onStart={() => {
+          // eslint-disable-next-line no-console
+          console.log('start');
+        }}
+        /* eslint-disable-next-line react/jsx-no-bind,@typescript-eslint/explicit-function-return-type */
+        onComplete={() => {
+          // eslint-disable-next-line no-console
+          console.log('completed');
+        }}
+      >
         {isRedVisible ? (
           <Child
             background="red"


### PR DESCRIPTION
The TransitionPresence receives "new" children when the parent component rerenders for whichever reason. More often than not the same component (JSX) is passed, so there is no need for a in/out animation.

This update expects all children of the TransitionPresence to have a `key` prop defined, and uses that to determine if a new child is passed and if it should trigger the beforeUnmount.

This update also includes the `onStart` and `onComplete` handlers on the TransitionPresence to trigger when transitions start and finish.