### PR TITLE
Make sure no out animations are triggered on rerender

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6623,10 +6623,9 @@
       "link": true
     },
     "node_modules/@mediamonks/react-hooks": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mediamonks/react-hooks/-/react-hooks-1.0.7.tgz",
-      "integrity": "sha512-3fW+yBSlNqpZdDknBHbAUpakHc/LuLmhy1r6wwtD7vPUSy4EHNpq8WRtVBX4GaQTS7Pb0v1XDnCEtY0BfoHSmw==",
-      "peer": true,
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mediamonks/react-hooks/-/react-hooks-1.0.8.tgz",
+      "integrity": "sha512-eQnF0Ib75TZwBUwKrZCCFPHLUYX+KJT6U+BjEnZQYydw/LR4ScWENgx2f4udtnvckZMcso1yx9fgpw+EDLg9oA==",
       "dependencies": {
         "@psimk/typed-object": "^1.0.4",
         "@types/lodash-es": "^4.17.6",
@@ -7475,7 +7474,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@psimk/typed-object/-/typed-object-1.0.4.tgz",
       "integrity": "sha512-UBqfjpmvqmfvLxdCqBwPsGRiU3FMge9NZlyDgeqhfQPtheeJiwfwC9mFJ+H9mZ0h0LxN1NP5UNLzpv9jUnk1TA==",
-      "peer": true,
       "peerDependencies": {
         "typescript": ">=4"
       }
@@ -10780,7 +10778,6 @@
       "version": "4.17.6",
       "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.6.tgz",
       "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
-      "peer": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -17366,8 +17363,7 @@
       "version": "3.11.4",
       "resolved": "https://npm.greensock.com/@gsap%2fbusiness/-/business-3.11.4.tgz",
       "integrity": "sha512-+rAtCKKYO+EXUSSjQdkk5EEyZEC+FKJGinwTzQCpMfyCZN/n2ogtSH2HAP80S4gRGhCjBJeNxwyHrnUvHNDlyA==",
-      "license": "This package should only be used by individuals/companies with an active Business Green Club GreenSock membership. See https://greensock.com/club/. Licensing: https://greensock.com/licensing/",
-      "peer": true
+      "license": "This package should only be used by individuals/companies with an active Business Green Club GreenSock membership. See https://greensock.com/club/. Licensing: https://greensock.com/licensing/"
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -20925,8 +20921,7 @@
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "peer": true
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -28615,7 +28610,7 @@
     },
     "packages/react-animation": {
       "name": "@mediamonks/react-animation",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^29.3.1",
@@ -28659,6 +28654,7 @@
         "@mediamonks/eslint-config-react": "^2.1.11",
         "@mediamonks/eslint-config-typescript": "^1.0.8",
         "@mediamonks/eslint-config-typescript-react": "^1.0.10",
+        "@mediamonks/react-hooks": "^1.0.8",
         "@storybook/addon-essentials": "^7.0.0-beta.21",
         "@storybook/addon-interactions": "^7.0.0-beta.21",
         "@storybook/addon-links": "^7.0.0-beta.21",
@@ -28672,6 +28668,7 @@
         "@testing-library/react": "^13.4.0",
         "@types/jest": "^29.2.4",
         "@types/react": "^18.0.26",
+        "gsap": "npm:@gsap/business@^3.11.4",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "storybook": "^7.0.0-beta.21",
@@ -33805,10 +33802,9 @@
       }
     },
     "@mediamonks/react-hooks": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@mediamonks/react-hooks/-/react-hooks-1.0.7.tgz",
-      "integrity": "sha512-3fW+yBSlNqpZdDknBHbAUpakHc/LuLmhy1r6wwtD7vPUSy4EHNpq8WRtVBX4GaQTS7Pb0v1XDnCEtY0BfoHSmw==",
-      "peer": true,
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@mediamonks/react-hooks/-/react-hooks-1.0.8.tgz",
+      "integrity": "sha512-eQnF0Ib75TZwBUwKrZCCFPHLUYX+KJT6U+BjEnZQYydw/LR4ScWENgx2f4udtnvckZMcso1yx9fgpw+EDLg9oA==",
       "requires": {
         "@psimk/typed-object": "^1.0.4",
         "@types/lodash-es": "^4.17.6",
@@ -33823,6 +33819,7 @@
         "@mediamonks/eslint-config-react": "^2.1.11",
         "@mediamonks/eslint-config-typescript": "^1.0.8",
         "@mediamonks/eslint-config-typescript-react": "^1.0.10",
+        "@mediamonks/react-hooks": "^1.0.8",
         "@storybook/addon-essentials": "^7.0.0-beta.21",
         "@storybook/addon-interactions": "^7.0.0-beta.21",
         "@storybook/addon-links": "^7.0.0-beta.21",
@@ -33836,6 +33833,7 @@
         "@testing-library/react": "^13.4.0",
         "@types/jest": "^29.2.4",
         "@types/react": "^18.0.26",
+        "gsap": "npm:@gsap/business@^3.11.4",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "storybook": "^7.0.0-beta.21",
@@ -34509,7 +34507,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@psimk/typed-object/-/typed-object-1.0.4.tgz",
       "integrity": "sha512-UBqfjpmvqmfvLxdCqBwPsGRiU3FMge9NZlyDgeqhfQPtheeJiwfwC9mFJ+H9mZ0h0LxN1NP5UNLzpv9jUnk1TA==",
-      "peer": true,
       "requires": {}
     },
     "@rollup/pluginutils": {
@@ -36983,7 +36980,6 @@
       "version": "4.17.6",
       "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.6.tgz",
       "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
-      "peer": true,
       "requires": {
         "@types/lodash": "*"
       }
@@ -42099,8 +42095,7 @@
     "gsap": {
       "version": "npm:@gsap/business@3.11.4",
       "resolved": "https://npm.greensock.com/@gsap%2fbusiness/-/business-3.11.4.tgz",
-      "integrity": "sha512-+rAtCKKYO+EXUSSjQdkk5EEyZEC+FKJGinwTzQCpMfyCZN/n2ogtSH2HAP80S4gRGhCjBJeNxwyHrnUvHNDlyA==",
-      "peer": true
+      "integrity": "sha512-+rAtCKKYO+EXUSSjQdkk5EEyZEC+FKJGinwTzQCpMfyCZN/n2ogtSH2HAP80S4gRGhCjBJeNxwyHrnUvHNDlyA=="
     },
     "handlebars": {
       "version": "4.7.7",
@@ -44782,8 +44777,7 @@
     "lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "peer": true
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/packages/react-transition-presence/package.json
+++ b/packages/react-transition-presence/package.json
@@ -38,6 +38,7 @@
     "@mediamonks/eslint-config-react": "^2.1.11",
     "@mediamonks/eslint-config-typescript": "^1.0.8",
     "@mediamonks/eslint-config-typescript-react": "^1.0.10",
+    "@mediamonks/react-hooks": "^1.0.8",
     "@storybook/addon-essentials": "^7.0.0-beta.21",
     "@storybook/addon-interactions": "^7.0.0-beta.21",
     "@storybook/addon-links": "^7.0.0-beta.21",
@@ -55,7 +56,9 @@
     "jest-environment-jsdom": "^29.3.1",
     "storybook": "^7.0.0-beta.21",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "gsap": "npm:@gsap/business@^3.11.4",
+    "@mediamonks/react-animation": "*"
   },
   "peerDependencies": {
     "react": ">=17"

--- a/packages/react-transition-presence/src/TransitionPresence/TransitionPresence.stories.tsx
+++ b/packages/react-transition-presence/src/TransitionPresence/TransitionPresence.stories.tsx
@@ -1,4 +1,7 @@
-/* eslint-disable react/no-multi-comp, react/jsx-no-literals */
+/* eslint-disable react/no-multi-comp, react/jsx-no-literals,no-console */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useAnimation } from '@mediamonks/react-animation';
+import gsap from 'gsap';
 import { type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import { useBeforeUnmount } from '../useBeforeUnmount/useBeforeUnmount.js';
 import { TransitionPresence } from './TransitionPresence.js';
@@ -9,6 +12,8 @@ export default {
 
 type ChildProps = {
   background: string;
+  duration?: number;
+  delayIn?: number;
   onClick(): void;
 };
 
@@ -16,35 +21,31 @@ type ChildProps = {
 function useRerender(): () => void {
   // eslint-disable-next-line react/hook-use-state
   const [count, setCount] = useState(0);
-  // eslint-disable-next-line no-console
   console.log('rerender', count);
   return () => {
     setCount((previous) => previous + 1);
   };
 }
 
-function Child({ background, onClick }: ChildProps): ReactElement {
+function Child({ background, onClick, duration = 1, delayIn = 0 }: ChildProps): ReactElement {
   const ref = useRef<HTMLButtonElement>(null);
 
+  useAnimation(() => {
+    console.log('animate-in', background);
+    return gsap.fromTo(ref.current, { opacity: 0 }, { opacity: 1, duration, delay: delayIn });
+  }, []);
+
   // show visible animation during "before unmount" lifecycle
-  useBeforeUnmount(() => {
-    const duration = 1000;
-    ref.current?.animate([{ opacity: '0' }], {
-      duration,
-    });
-    // Defer unmounting for 1 second
-    return new Promise((resolve) => {
-      setTimeout(resolve, duration);
-    });
+  useBeforeUnmount(async () => {
+    console.log('animate-out', background);
+    return gsap.fromTo(ref.current, { opacity: 1 }, { opacity: 0, duration });
   }, []);
 
   // show when mounted/unmounted
   useEffect(() => {
-    // eslint-disable-next-line no-console
     console.log('mounted', background);
 
     return () => {
-      // eslint-disable-next-line no-console
       console.log('unmounted', background);
     };
   }, []);
@@ -73,6 +74,7 @@ export function DeferFlow(): ReactElement {
       <TransitionPresence>
         {isRedVisible ? (
           <Child
+            key="red"
             background="red"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={(): void => {
@@ -81,6 +83,7 @@ export function DeferFlow(): ReactElement {
           />
         ) : (
           <Child
+            key="blue"
             background="blue"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={(): void => {
@@ -103,6 +106,7 @@ export function CrossFlow(): ReactElement {
       <TransitionPresence crossFlow>
         {isRedVisible ? (
           <Child
+            key="red"
             background="red"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={(): void => {
@@ -111,6 +115,7 @@ export function CrossFlow(): ReactElement {
           />
         ) : (
           <Child
+            key="blue"
             background="blue"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={(): void => {
@@ -183,6 +188,7 @@ export function StartCompleteCallbacks(): ReactElement {
       >
         {isRedVisible ? (
           <Child
+            key="red"
             background="red"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={(): void => {
@@ -191,6 +197,7 @@ export function StartCompleteCallbacks(): ReactElement {
           />
         ) : (
           <Child
+            key="blue"
             background="blue"
             // eslint-disable-next-line react/jsx-no-bind
             onClick={(): void => {
@@ -202,5 +209,51 @@ export function StartCompleteCallbacks(): ReactElement {
 
       <div style={{ marginTop: 24 }}>Click the square (isRedVisible: {String(isRedVisible)})</div>
     </>
+  );
+}
+
+const initialItems = ['red', 'blue', 'green', 'yellow'];
+export function RerenderUnmountIssue(): ReactElement {
+  const [items, setItems] = useState(() => initialItems);
+  const rerender = useRerender();
+
+  const onReset = useCallback(() => {
+    setItems(initialItems);
+  }, [setItems]);
+  const onNextItem = useCallback(() => {
+    setItems((previous) => {
+      const [first, ...rest] = previous;
+      return [...rest, first];
+    });
+    // This would trigger out animations when
+    // not properly handled in the TransitionPresence
+    setTimeout(() => {
+      rerender();
+    }, 100);
+  }, [setItems, rerender]);
+
+  return (
+    <div>
+      <div style={{ display: 'flex' }}>
+        {items.map((item, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={index} style={{ width: index === 0 ? 400 : 200 }}>
+            <TransitionPresence crossFlow={index <= 1}>
+              <Child
+                /* eslint-disable-next-line react/no-array-index-key */
+                key={item + index}
+                background={item}
+                onClick={onNextItem}
+                duration={2}
+                delayIn={0}
+              />
+            </TransitionPresence>
+          </div>
+        ))}
+      </div>
+      <button type="button" onClick={onReset}>
+        Reset
+      </button>
+    </div>
   );
 }

--- a/packages/react-transition-presence/src/TransitionPresence/TransitionPresence.test.tsx
+++ b/packages/react-transition-presence/src/TransitionPresence/TransitionPresence.test.tsx
@@ -25,7 +25,7 @@ describe('TransitionPresence', () => {
   it('should render children', async () => {
     const result = render(
       <TransitionPresence>
-        <Child beforeUnmount={(): Promise<void> => Promise.resolve()} />
+        <Child key="key" beforeUnmount={(): Promise<void> => Promise.resolve()} />
       </TransitionPresence>,
     );
 
@@ -36,6 +36,7 @@ describe('TransitionPresence', () => {
     const result = render(
       <TransitionPresence>
         <Child
+          key="key"
           beforeUnmount={(): Promise<void> =>
             new Promise<void>((resolve) => {
               setTimeout(resolve, 1000);


### PR DESCRIPTION
If a TransitionPresence renders again after an out animation has already started, it would call the out animations on the newly rendered components, causing everything to disappear.

This update makes sure the "transition out" logic will not trigger during rendering when the children and deferredChildren haven't changed.