### PR TITLE
Fix issue where useExposedAnimations caused re-renders

### DIFF
--- a/packages/react-animation/src/useExposedAnimations/useExposedAnimations.stories.tsx
+++ b/packages/react-animation/src/useExposedAnimations/useExposedAnimations.stories.tsx
@@ -1,14 +1,26 @@
 /* eslint-disable react/jsx-no-literals, react/no-multi-comp */
 import { arrayRef, ensuredForwardRef } from '@mediamonks/react-hooks';
 import gsap from 'gsap';
-import { useRef, type ReactElement, useCallback } from 'react';
+import { useRef, type ReactElement, useCallback, useState, useEffect } from 'react';
 import { useAnimation } from '../useAnimation/useAnimation.js';
 import { useExposeAnimation } from '../useExposeAnimation/useExposeAnimation.js';
+import { useScrollAnimation } from '../useScrollAnimation/useScrollAnimation.js';
 import { useExposedAnimations } from './useExposedAnimations.js';
 
 export default {
   title: 'hooks/useExposedAnimations',
 };
+
+// Forces a re-render, useful to test for unwanted side-effects
+function useRerender(): () => void {
+  // eslint-disable-next-line react/hook-use-state
+  const [count, setCount] = useState(0);
+  // eslint-disable-next-line no-console
+  console.log('rerender', count);
+  return () => {
+    setCount((previous) => previous + 1);
+  };
+}
 
 const ChildItem = ensuredForwardRef<HTMLDivElement, unknown>((_, ref): ReactElement => {
   const animation = useAnimation(
@@ -86,6 +98,47 @@ export function PassingArrayRefs(): ReactElement {
         }}
       >
         Restart animations
+      </button>
+    </div>
+  );
+}
+
+export function RerenderTesting(): ReactElement {
+  const rerender = useRerender();
+  const ref = useRef<Array<HTMLDivElement | null>>([]);
+  const animations = useExposedAnimations(ref);
+
+  // eslint-disable-next-line no-console
+  console.log('useExposedAnimations', animations);
+
+  // if there is something wrong in the useExposedAnimations, this will keep re-rendering
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log('animations updated', animations);
+  }, [animations]);
+
+  // if there is something wrong in the useExposedAnimations, this will cause a new animation
+  // to trigger, which will cause 'animations' to update, which will cause a re-render, etc
+  useScrollAnimation(() => gsap.timeline(), [animations]);
+
+  return (
+    <div>
+      <p>
+        If this is working as intended, there shouldn&apos;t be an endless streams of logs in the
+        console
+      </p>
+      {Array.from({ length: 3 }).map((_, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <ChildItem key={index} ref={arrayRef(ref, index)} />
+      ))}
+      <button
+        type="button"
+        /* eslint-disable-next-line react/jsx-no-bind */
+        onClick={(): void => {
+          rerender();
+        }}
+      >
+        Trigger rerender
       </button>
     </div>
   );

--- a/packages/react-animation/src/useExposedAnimations/useExposedAnimations.ts
+++ b/packages/react-animation/src/useExposedAnimations/useExposedAnimations.ts
@@ -15,11 +15,26 @@ export function useExposedAnimations(
     () =>
       animations.listen(() => {
         if (arrayRef.current) {
-          setExposedAnimations(arrayRef.current.map((ref) => animations.get(ref)));
+          const newAnimations = arrayRef.current.map((ref) => animations.get(ref));
+          // this should only be done when the refs have been updated, otherwise we're returning
+          // a new array ref with the same values, which will cause a re-render
+          setExposedAnimations((currentAnimations) =>
+            areArraysEqual(currentAnimations, newAnimations) ? currentAnimations : newAnimations,
+          );
         }
       }),
     [arrayRef],
   );
 
   return exposedAnimations;
+}
+
+function areArraysEqual<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return (
+    a.every((value, index) => value === b[index]) && b.every((value, index) => value === a[index])
+  );
 }


### PR DESCRIPTION
When _any_ animation was being "updated" in the global animation map, the useExposedAnimations would do a setState with a new array reference of the same array values, causing a rerender.

When this animation was used in another animation (normal that was exposed again, or a scroll animation that exposes itself), it would cause an infinite rerender loop.

Having the new and old array values compared before setting a new one solves the issue.

The accompanied Story reproduced the original issue, and behaves properly after the fix.