### PR TITLE
Improve re-render checking using memo in TransitionPresence

### DIFF
--- a/packages/react-transition-presence/src/TransitionPresence/useOld.ts
+++ b/packages/react-transition-presence/src/TransitionPresence/useOld.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export function useOld<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}


### PR DESCRIPTION
**Improve rerender checks in TransitionPresence**

The switch to `memo` didn't work out since it would block too much
rendering when updating other props (or children) of the children passed
to the TransitionPresence.

A story is added for the above scenario, so we won't make the same
mistake in the future.

Some comments and logging is added since this component will receive
other updates shortly.

#92 