### PR TITLE
Feature/split text children wrapper support

### DIFF
--- a/packages/react-animation/src/SplitTextWrapper/SplitTextWrapper.mdx
+++ b/packages/react-animation/src/SplitTextWrapper/SplitTextWrapper.mdx
@@ -41,6 +41,39 @@ function Component(): ReactElement {
 
 <Canvas of={stories.Children} />
 
+## Rendering children wraped in a parent element
+
+The `SplitTextWrapper` renders to HTML inside the component to make sure that compnents from the
+vDOM are not changed on render making them untargetable in the created SplitText instance. **_This
+time the children being wrap in another parent element_**
+
+> Warning: state inside the rendered children is lost when the children change.
+
+```tsx
+function Component(): ReactElement {
+  const splitTextRef = useRef<SplitText>(null);
+
+  useEffect(() => {
+    // Do something with `splitTextRef.current`
+  });
+
+  return (
+    <SplitTextWrapper ref={splitTextRef}>
+      <p>
+        Lorem ipsum dolor sit <i>amet consectetur</i>
+        <br /> adipisicing elit. <b>Tenetur perspiciatis</b> eius ea, ratione,
+        <br /> illo molestias, <code>quia sapiente</code> modi quo
+        <br /> molestiae temporibus.
+      </p>
+    </SplitTextWrapper>
+  );
+}
+```
+
+### Demo
+
+<Canvas of={stories.ChildrenWrap} />
+
 ## Using dangerouslySetInnerHTML
 
 The children are rendered to a string, this is not necessary when the `dangerouslySetInnerHTML`

--- a/packages/react-animation/src/SplitTextWrapper/SplitTextWrapper.stories.tsx
+++ b/packages/react-animation/src/SplitTextWrapper/SplitTextWrapper.stories.tsx
@@ -88,6 +88,80 @@ export const Children: Story = {
   },
 };
 
+export const ChildrenWrap: Story = {
+  render(): ReactElement {
+    const splitTextRef = useRef<SplitText>(null);
+
+    const animation = useAnimation(() => {
+      if (!splitTextRef.current) {
+        return;
+      }
+
+      return gsap.from(splitTextRef.current.lines, {
+        paused: true,
+        y: 20,
+        opacity: 0,
+        duration: 0.2,
+        stagger: 0.05,
+      });
+    }, []);
+
+    const onPlay = useCallback(() => {
+      animation.current?.play(0);
+    }, [animation]);
+
+    return (
+      <>
+        <SplitTextWrapper ref={splitTextRef} variables={{ type: 'lines' }} data-testid="wrapper">
+          <p>
+            Lorem ipsum dolor sit <i>amet consectetur</i>
+            <br /> adipisicing elit. <b>Tenetur perspiciatis</b> eius ea, ratione,
+            <br /> illo molestias, <code data-testid="code">quia sapiente</code> modi quo
+            <br /> molestiae temporibus.
+          </p>
+        </SplitTextWrapper>
+        <button
+          onClick={onPlay}
+          type="button"
+          style={{
+            position: 'relative',
+            marginBlockStart: 20,
+            cursor: 'pointer',
+          }}
+        >
+          Play
+        </button>
+      </>
+    );
+  },
+  async play({ canvasElement }) {
+    const canvas = within(canvasElement);
+    const wrapper = canvas.getByTestId('wrapper');
+
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper.childElementCount).toEqual(4);
+
+    // Wait 2 ticks for styles to be initialized
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(wrapper.children[0]).toHaveStyle({ opacity: '0' });
+    expect(wrapper.children[3]).toHaveStyle({ opacity: '0' });
+
+    await userEvent.click(canvas.getByText('Play'));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 200 + wrapper.childElementCount * 50);
+    });
+
+    expect(wrapper.children[0]).toHaveStyle({ opacity: '1' });
+    expect(wrapper.children[3]).toHaveStyle({ opacity: '1' });
+  },
+};
+
 export const DangerouslySetInnerHtml: Story = {
   render(): ReactElement {
     const splitTextRef = useRef<SplitText>(null);

--- a/packages/react-animation/src/SplitTextWrapper/SplitTextWrapper.tsx
+++ b/packages/react-animation/src/SplitTextWrapper/SplitTextWrapper.tsx
@@ -53,10 +53,14 @@ export const SplitTextWrapper: SplitTextWrapperComponent = ensuredForwardRef(
         return;
       }
 
+      /**
+       * Detecting the if firstChild is an element only if there is only one child
+       */
       const content =
-        element.firstChild?.nodeType === Node.ELEMENT_NODE
-          ? element.querySelector((element.firstChild as HTMLElement).tagName.toLowerCase())
+        element.children.length === 1 && element.firstChild?.nodeType === Node.ELEMENT_NODE
+          ? (element.firstChild as HTMLElement)
           : element;
+
       ref.current = new SplitText(content, variables);
     };
 

--- a/packages/react-animation/src/SplitTextWrapper/SplitTextWrapper.tsx
+++ b/packages/react-animation/src/SplitTextWrapper/SplitTextWrapper.tsx
@@ -53,7 +53,11 @@ export const SplitTextWrapper: SplitTextWrapperComponent = ensuredForwardRef(
         return;
       }
 
-      ref.current = new SplitText(element, variables);
+      const content =
+        element.firstChild?.nodeType === Node.ELEMENT_NODE
+          ? element.querySelector((element.firstChild as HTMLElement).tagName.toLowerCase())
+          : element;
+      ref.current = new SplitText(content, variables);
     };
 
     const Component = (as ?? 'div') as unknown as ComponentType<unknown>;


### PR DESCRIPTION
Taking into account the following situation:

When passing a child to SplitText that is wrap around another HTML element, splitting by lines would consider this element as one line. 

In this scenario, we would like SplitText to split lines of the parent content.